### PR TITLE
Feature/#7: Improved `@mixin background` which now generates `px` & `rem` units

### DIFF
--- a/mixins/helpers/media/_background.scss
+++ b/mixins/helpers/media/_background.scss
@@ -75,7 +75,8 @@
 ///
 ///     @media only screen and (-webkit-min-device-pixel-ratio: 2), ..., only screen and (min-resolution: 2dppx) {
 ///       background-image: url(../../images/icons/download@2x.png);
-///       background-size: 300px 60px;
+///       background-size: 300px 60px; // Fallback for IE8.
+///       background-size: 18.75rem 3.75rem;
 ///     }
 ///   }
 ///
@@ -84,6 +85,7 @@
 /// @requires {variable} image-fallback-extension
 /// @requires {variable} image-retina-media-query
 /// @requires {variable} enable-retina-fallback
+/// @requires {mixin} rem
 
 @mixin background(
   $color: false,
@@ -106,11 +108,11 @@
     }
 
     @if $image {
+      @include rem('position', $image-position);
       image: url(#{$image-path}/#{$image}.#{$image-extension});
       repeat: $image-repeat;
-      position: $image-position;
       @if $image-size {
-        size: $image-size;
+        @include rem('size', $image-size);
       }
     }
   }
@@ -118,8 +120,8 @@
   @if $image and $retina-fallback {
     @media #{$image-retina-media-query} {
       background: {
+        @include rem('size', $retina-width $retina-height);
         image: url(#{$image-path}/#{$image}#{$retina-suffix}.#{$image-extension});
-        size: $retina-width $retina-height;
       }
     }
   }


### PR DESCRIPTION
This pull request contains the `@mixin background` improvement which generates `px` & `rem` units (using the `@mixin rem`) what now pushes support back to _Microsoft_ **Internet Explorer 6 to 8**.