### PR TITLE
Bugfix/#11: Updated framework using the `calc()` function for division

### DIFF
--- a/functions/helpers/general/_strip-units.scss
+++ b/functions/helpers/general/_strip-units.scss
@@ -18,5 +18,5 @@
   $value
 ) {
 
-  @return ($value / ($value * 0 + 1));
+  @return calc($value / ($value * 0 + 1));
 }

--- a/mixins/layout/general/_breakpoint.scss
+++ b/mixins/layout/general/_breakpoint.scss
@@ -141,7 +141,7 @@
 ///
 ///   // CSS Output
 ///   //
-///   @media (min-width: 576px) and (max-width: 991px) {
+///   @media (min-width: 576px) and (max-width: 1229px) {
 ///     .element {
 ///       ...
 ///     }

--- a/mixins/layout/grid-system/_grid.scss
+++ b/mixins/layout/grid-system/_grid.scss
@@ -183,8 +183,8 @@
 
   @extend %column-defaults;
   padding: {
-    @include rem('right', ($gutter / 2));
-    @include rem('left', ($gutter / 2));
+    @include rem('right', calc($gutter / 2));
+    @include rem('left', calc($gutter / 2));
   }
 }
 

--- a/mixins/layout/grid-system/_grid.scss
+++ b/mixins/layout/grid-system/_grid.scss
@@ -37,8 +37,8 @@
 
   @extend %container-defaults;
   padding: {
-    @include rem('right', ($gutter / 2));
-    @include rem('left', ($gutter / 2));
+    @include rem('right', calc($gutter / 2));
+    @include rem('left', calc($gutter / 2));
   }
 }
 

--- a/mixins/layout/grid-system/_grid.scss
+++ b/mixins/layout/grid-system/_grid.scss
@@ -141,8 +141,8 @@
 
   @extend %row-defaults;
   margin: {
-    @include rem('right', ($gutter / -2));
-    @include rem('left', ($gutter / -2));
+    @include rem('right', calc($gutter / -2));
+    @include rem('left', calc($gutter / -2));
   }
 }
 

--- a/mixins/typography/general/_rem.scss
+++ b/mixins/typography/general/_rem.scss
@@ -68,7 +68,7 @@
             $rem: append($rem, $value);
           }
           @else {
-            $rem: append($rem, ($val / $root + rem));
+            $rem: append($rem, (calc($val / $root) + rem));
           }
         }
         @else if $unit == 'rem' {

--- a/placeholders/layout/grid-system/_grid.scss
+++ b/placeholders/layout/grid-system/_grid.scss
@@ -84,7 +84,7 @@
 %column-ready-defaults {
   @extend %column-defaults;
   padding: {
-    @include rem('right', ($grid-gutter-width / 2));
-    @include rem('left', ($grid-gutter-width / 2));
+    @include rem('right', calc($grid-gutter-width / 2));
+    @include rem('left', calc($grid-gutter-width / 2));
   }
 }


### PR DESCRIPTION
This pull request contains all the updates that temporarily use the `calc()` function to avoid the deprecation warning print regarding the `/` operator.