### PR TITLE
Hotfix/#13: Fixed issue we have with build scripts

### DIFF
--- a/functions/helpers/general/_strip-units.scss
+++ b/functions/helpers/general/_strip-units.scss
@@ -18,5 +18,6 @@
   $value
 ) {
 
-  @return calc($value / ($value * 0 + 1));
+  $strip: ($value * 0 + 1);
+  @return calc($value / $strip);
 }


### PR DESCRIPTION
This pull request contains the fix that relates to the error we have with build scripts. This error was due to the following operation within the `calc()` function in:
https://github.com/smillart/Framework-SASS-Source-Files/blob/78a0e048219b118fcf3463df7a9419787bac2c85/functions/helpers/general/_strip-units.scss#L21